### PR TITLE
Add differential temperature units

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,14 +166,14 @@ Exponentiation is also supported.
 There are two notions of temperature which may be desired when converting between units.
 
 #### Temperature
-One degree kelvin is very cold: 
+One kelvin is very cold: 
 ```ruby
 Unitwise(1, 'K').convert_to('[degF]')
 # => #<Unitwise::Measurement value=-457.87 unit=[degF]>
 ```
 
 #### Differential temperature
-One degree kelvin is equivalent to 9/5 times one degree Fahrenheit.
+One kelvin is equivalent to 9/5 times one degree Fahrenheit.
 ```ruby
 Unitwise(1, 'K').convert_to('[deltaF]')
 # => #<Unitwise::Measurement value=9/5 unit=[deltaF]>

--- a/README.md
+++ b/README.md
@@ -161,6 +161,27 @@ Exponentiation is also supported.
 # => #<Unitwise::Measurement value=1 unit=liter>
 ```
 
+
+### Temperature and differential temperature
+There are two notions of temperature which may be desired when converting between units.
+
+#### Temperature
+One degree kelvin is very cold: 
+```ruby
+Unitwise(1, 'K').convert_to('[degF]')
+# => #<Unitwise::Measurement value=-457.87 unit=[degF]>
+```
+
+#### Differential temperature
+One degree kelvin is equivalent to 9/5 times one degree Fahrenheit.
+```ruby
+Unitwise(1, 'K').convert_to('[deltaF]')
+# => #<Unitwise::Measurement value=9/5 unit=[deltaF]>
+```
+
+
+
+There are `[deltaF]` and `[deltaC]` units available for differential Fahrenheit and Celsius degrees.
 ### Unit Names and Atom Codes
 
 This library is based around the units in the UCUM specification, which is

--- a/README.md
+++ b/README.md
@@ -179,8 +179,6 @@ Unitwise(1, 'K').convert_to('[deltaF]')
 # => #<Unitwise::Measurement value=9/5 unit=[deltaF]>
 ```
 
-
-
 There are `[deltaF]` and `[deltaC]` units available for differential Fahrenheit and Celsius degrees.
 ### Unit Names and Atom Codes
 

--- a/data/derived_unit.yaml
+++ b/data/derived_unit.yaml
@@ -264,6 +264,18 @@
   :metric: true
   :special: true
   :arbitrary: false
+- :names: delta Celsius
+  :symbol: "Δ°C"
+  :primary_code: "[deltaC]"
+  :secondary_code: "[DELTAC]"
+  :scale:
+    :value: 1
+    :unit_code: K
+  :classification: heat
+  :property: temperature
+  :metric: true
+  :special: false
+  :arbitrary: false
 - :names: tesla
   :symbol: T
   :primary_code: T
@@ -2231,6 +2243,18 @@
   :property: temperature
   :metric: false
   :special: true
+  :arbitrary: false
+- :names: delta Fahrenheit
+  :symbol: "Δ°F"
+  :primary_code: "[deltaF]"
+  :secondary_code: "[DELTAF]"
+  :scale:
+    :value: 5
+    :unit_code: K/9
+  :classification: heat
+  :property: temperature
+  :metric: false
+  :special: false
   :arbitrary: false
 - :names: degree Rankine
   :symbol: "°R"


### PR DESCRIPTION
Add units of differential temperature for Fahrenheit and Celsius. This is necessary for conversions of compound units involving temperature, like [R-value](https://en.wikipedia.org/wiki/R-value_(insulation)#R-value_definition).